### PR TITLE
Fix detecting new spotify versions

### DIFF
--- a/spotifywm.cpp
+++ b/spotifywm.cpp
@@ -41,7 +41,7 @@ void spotifywm_init(void) {
 #define INTERCEPT(ReturnType, SymbolName, ...) \
 		typedef ReturnType (*TYPE_NAME(SymbolName))(__VA_ARGS__); \
 	static void * const BASE_NAME(SymbolName) = dlsym(RTLD_NEXT, STR(SymbolName)); \
-	ReturnType SymbolName(__VA_ARGS__)
+	extern "C" ReturnType SymbolName(__VA_ARGS__)
 #define BASE(SymbolName) ((TYPE_NAME(SymbolName))BASE_NAME(SymbolName))
 
 INTERCEPT(int, XMapWindow,

--- a/spotifywm.cpp
+++ b/spotifywm.cpp
@@ -8,6 +8,10 @@
 #include <dlfcn.h>
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
+#include <X11/Xproto.h>		/* to declare xEvent */
+#include <xcb/xproto.h>
+#include <xcb/xcb.h>
+#include <xcb/xcbext.h>
 
 #define STR_(x) # x
 #define STR(x)  STR_(x)
@@ -50,13 +54,42 @@ INTERCEPT(int, XMapWindow,
 ) {
 	XClassHint* classHint;
 
-	fprintf(stderr, "[spotifywm] spotify window found\n");
+	fprintf(stderr, "[spotifywm] spotify window %lx found\n", w);
 	classHint = XAllocClassHint();
 	if (classHint) {
-		classHint->res_name = "spotify";
-		classHint->res_class = "Spotify";
+		classHint->res_name = (char*)"spotify";
+		classHint->res_class = (char*)"Spotify";
 		XSetClassHint(dpy, w, classHint);
 		XFree(classHint);
 	}
 	return BASE(XMapWindow)(dpy, w);
+}
+
+INTERCEPT(unsigned int, xcb_send_request,
+	xcb_connection_t *c,
+	int flags,
+	struct iovec *vector,
+	const xcb_protocol_request_t *request 
+) {
+	// Check if we are sending a MapWindow request
+	// This code is called from chromium's source code:
+	// ui/gfx/x/generated_protos/xproto.cc in XProto::MapWindow
+	if(request->count >= 1 && vector[0].iov_len >= 8 && ((uint8_t*)vector[0].iov_base)[0] == 8) {
+		uint32_t window_id = ((uint32_t*)vector[0].iov_base)[1];
+
+		fprintf(stderr, "[spotifywm] spotify window %x found\n", window_id);
+		
+		// Don't use the same XCB connection as spotify is checking the returned number
+		Display* dpy = XOpenDisplay(NULL);
+		XClassHint* classHint = XAllocClassHint();
+		if (classHint) {
+			classHint->res_name = (char*)"spotify";
+			classHint->res_class = (char*)"Spotify";
+			XSetClassHint(dpy, window_id, classHint);
+			XFree(classHint);
+		}
+		XCloseDisplay(dpy);
+	}
+	
+	return BASE(xcb_send_request)(c, flags, vector, request);
 }


### PR DESCRIPTION
Newer spotify versions use newer chromium code which forge X11 requests itself, thus XMapWindow is not called anymore (except for cases we don't care about).
Instead, https://github.com/chromium/chromium/blob/a627d0d0d1bc5ece5c3084388d96d250cb6a5e31/ui/gfx/x/generated_protos/xproto.cc#L3488 will call xcb_send_request with a already constructed request.

So we need to intercept xcb_send_request, parse the request buffer to check if it's a MapWindow request, and set the class if it is a MapWindow request.

I don't use xcb_send_request to set the window class as chromium will check the returned value (which seems to be a request index). So I'm using xlib to open the display and then do the same as when intercepting XMapWindow (even if the performance might not be the best, its good enough as this is called only when starting spotify).

Fixes: #8